### PR TITLE
add multiblock

### DIFF
--- a/vm/cfg.cpp
+++ b/vm/cfg.cpp
@@ -26,6 +26,7 @@
 #include "common.hpp"
 #include "constraints.hpp"
 #include "cfg.hpp"
+#include "multiblock.hpp"
 
 using boost::optional;
 using std::to_string;
@@ -82,9 +83,12 @@ void build_cfg(cfg_t& cfg, std::vector<ebpf_inst> insts, ebpf_prog_type prog_typ
     }
     for (pc_t pc = 0; pc < insts.size(); pc++) {
         auto inst = insts[pc];
-
-        regs.exec(inst, cfg.insert(label(pc)), cfg.insert(exit_label(pc)), pc, cfg);
-
+        cfg.insert(label(pc));
+        cfg.insert(exit_label(pc));
+        {
+            multiblock_t mblock{cfg, label(pc), exit_label(pc)};
+            regs.exec(inst, mblock);
+        }
         if (inst.opcode == EBPF_OP_EXIT) {
             cfg.set_exit(exit_label(pc));
             continue;

--- a/vm/common.hpp
+++ b/vm/common.hpp
@@ -30,3 +30,6 @@ using crab::cfg_impl::basic_block_label_t;
 /// CFG over integers
 using cfg_t         = crab::cfg::Cfg<basic_block_label_t, varname_t, ikos::z_number>;
 using basic_block_t = cfg_t::basic_block_t;
+using var_t     = ikos::variable<ikos::z_number, varname_t>;
+using lin_cst_t = ikos::linear_constraint<ikos::z_number, varname_t>;
+using lin_exp_t = ikos::linear_expression<ikos::z_number, varname_t>;

--- a/vm/multiblock.hpp
+++ b/vm/multiblock.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <tuple>
+
+#include <boost/optional.hpp>
+
+#include "common.hpp"
+#include "constraints.hpp"
+#include "cfg.hpp"
+
+using std::vector;
+using std::string;
+using std::tuple;
+
+class multiblock_t
+{
+    cfg_t& cfg;
+    basic_block_label_t current;
+    basic_block_label_t exit;
+    bool connected = false;
+    basic_block_t& last()
+    {
+        return cfg.get_node(exit);
+    }
+public:
+
+    multiblock_t(cfg_t& cfg, basic_block_label_t enter, basic_block_label_t exit) 
+    : cfg(cfg), current(enter), exit(exit) { }
+
+    multiblock_t(multiblock_t&& other)
+    : cfg(other.cfg), current(other.current), exit(other.exit) { other.connected = true; }
+    
+    multiblock_t(const multiblock_t& other) = delete;
+    
+    ~multiblock_t()
+    {
+        if (!connected) {
+            block() >> cfg.get_node(exit);
+        }
+    }
+
+    basic_block_t& block()
+    {
+        return cfg.get_node(current);
+    }
+
+    void assertion(lin_cst_t cst) {
+        block().assertion(cst, {current, (unsigned int)first_num(current), 0});
+    }
+
+    void assume(lin_cst_t cst) {
+        block().assume(cst);
+    }
+
+    void assign(var_t lhs, var_t rhs) {
+        block().assign(lhs, rhs);
+    }
+
+    void assign(var_t lhs, int rhs) {
+        block().assign(lhs, rhs);
+    }
+
+    void havoc(var_t lhs) {
+        block().havoc(lhs);
+    }
+
+    multiblock_t branch(basic_block_label_t suffix)
+    {
+        connected = true;
+        basic_block_label_t e = current + ":" + suffix;
+        basic_block_label_t x = current + ":" + suffix + ".exit";
+        block() >> cfg.insert(e);
+        cfg.insert(x) >> cfg.get_node(exit);
+        return {cfg, e, x};
+    }
+
+    std::tuple<multiblock_t, multiblock_t> split(string suffix1, string suffix2) {
+        multiblock_t b1{cfg, cfg.insert(current + ":" + suffix1).label(), cfg.insert(current + ":" + suffix1 + ".exit").label()};
+        multiblock_t b2{cfg, cfg.insert(current + ":" + suffix2).label(), cfg.insert(current + ":" + suffix2 + ".exit").label()};
+        block() >> b1.block();
+        block() >> b2.block();
+        current = current + ":ctd."; // TODO: make sure it's unique
+        cfg.insert(current);
+        b1.last() >> block();
+        b2.last() >> block();
+        return {std::move(b1), std::move(b2)};
+    }
+};

--- a/vm/prototypes.c
+++ b/vm/prototypes.c
@@ -819,7 +819,7 @@ const struct bpf_func_proto* prototypes[81] = {
 	FN(set_hash),
 	FN(setsockopt),
 	FN(skb_adjust_room),
-	FN(sk_redirect_map),// without sk_ originally
+	FN(redirect),// redirect_map originally
 	FN(sk_redirect_map),
 	FN(sock_map_update),
 	FN(xdp_adjust_meta),


### PR DESCRIPTION
This is an attempt to "play down" the role of the cfg in the generation of constraints for a single instruction - specifically, an attempt to handle disjunctions more cleanly. The cfg is passed around inside a "multiblock" that is a single-entry, single-exit DAG.

I'm not at all sure that it's worth the additional abstraction and complexity, and it is not a clean-cut abstraction either. But it does look cleaner in the constraints part. It's only here as a suggestion.

This PR handles checking function arguments to be "either pointer or null", which (at the moment) is not handled in master or in mem-domain.